### PR TITLE
Update jest to the latest version 🚀

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,17 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.35.tgz",
+      "integrity": "sha512-l0SE8cl9DUIY4hYAFAKTLX3F2Yr14Qri7uTsuI7iegB5E4KyQy4XY72L3VOxmj6kwR/RDQURoKYr2NzyETGo7A==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.1.0",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
     "@types/jest": {
       "version": "21.1.2",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-21.1.2.tgz",
@@ -164,9 +175,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "dev": true,
       "requires": {
         "lodash": "4.17.4"
@@ -290,13 +301,31 @@
       }
     },
     "babel-jest": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.2.0.tgz",
-      "integrity": "sha512-O0W2qLoWu1QOoOGgxiR2JID4O6WSpxPiQanrkyi9SSlM0PJ60Ptzlck47lhtnr9YZO3zYOsxHwnyeWJ6AffoBQ==",
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.0.1.tgz",
+      "integrity": "sha512-wn09vFAchJeSAQlQ+tuI7ibHwcr03IrTJPTZpPoL8k/Ot9r9r2NpUIkqloy6qn3y8NSlTLJubLEnZkswo8zdIg==",
       "dev": true,
       "requires": {
         "babel-plugin-istanbul": "4.1.5",
-        "babel-preset-jest": "21.2.0"
+        "babel-preset-jest": "22.0.1"
+      },
+      "dependencies": {
+        "babel-plugin-jest-hoist": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.0.1.tgz",
+          "integrity": "sha512-YtFAm9HEg/kMg9qw77QPa81RdHa2b7yJTVTKbQV6TU7UI2gYsO8b2lHJwejJ2lZWXE7rHm7epuPIGGdm1XGGIA==",
+          "dev": true
+        },
+        "babel-preset-jest": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.0.1.tgz",
+          "integrity": "sha512-JqTyoxwbCQxuqfbANfVS5yKUd9LrNYapZjsrzm/I8hFIQ92ReDPDcaupXtbJIH3JZlHHpuiRzHLOdoc5O820Qw==",
+          "dev": true,
+          "requires": {
+            "babel-plugin-jest-hoist": "22.0.1",
+            "babel-plugin-syntax-object-rest-spread": "6.13.0"
+          }
+        }
       }
     },
     "babel-messages": {
@@ -463,6 +492,13 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
+      "dev": true,
+      "optional": true
+    },
     "boom": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
@@ -492,6 +528,12 @@
         "preserve": "0.2.0",
         "repeat-element": "1.1.2"
       }
+    },
+    "browser-process-hrtime": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+      "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+      "dev": true
     },
     "browser-resolve": {
       "version": "1.11.2",
@@ -586,9 +628,9 @@
       }
     },
     "ci-info": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
-      "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
       "dev": true
     },
     "cliui": {
@@ -752,9 +794,9 @@
       }
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -781,6 +823,16 @@
         "strip-bom": "2.0.0"
       }
     },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -796,10 +848,22 @@
         "repeating": "2.0.1"
       }
     },
+    "detect-newline": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+      "dev": true
+    },
     "diff": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.0.tgz",
+      "integrity": "sha512-WpwuBlZ2lQRFa4H/4w49deb9rJLot9KmqrKKjMc9qBl7CID+DdC2swoa34ccRl+anL2B6bLp6TjFdIdnzekMBQ==",
       "dev": true
     },
     "ecc-jsbn": {
@@ -812,15 +876,6 @@
         "jsbn": "0.1.1"
       }
     },
-    "errno": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-      "dev": true,
-      "requires": {
-        "prr": "0.0.0"
-      }
-    },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
@@ -828,6 +883,30 @@
       "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
+      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "escape-string-regexp": {
@@ -1053,6 +1132,12 @@
         "for-in": "1.0.2"
       }
     },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -1085,6 +1170,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "get-caller-file": {
@@ -1166,9 +1257,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
         "async": "1.5.2",
@@ -1208,6 +1299,15 @@
       "requires": {
         "ajv": "5.2.3",
         "har-schema": "2.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -1343,14 +1443,26 @@
         "builtin-modules": "1.1.1"
       }
     },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
     "is-ci": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.1"
+        "ci-info": "1.1.2"
       }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -1427,10 +1539,25 @@
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
     "is-typedarray": {
@@ -1473,22 +1600,39 @@
       "dev": true
     },
     "istanbul-api": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.14.tgz",
-      "integrity": "sha1-JbxXAffGgMD//5E95G42GaOm5oA=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.2.1.tgz",
+      "integrity": "sha512-oFCwXvd65amgaPCzqrR+a2XjanS1MvpXN6l/MlMUTv6uiA1NOgGX+I0uyq8Lg3GDxsxPsaP1049krz3hIJ5+KA==",
       "dev": true,
       "requires": {
-        "async": "2.5.0",
+        "async": "2.6.0",
         "fileset": "2.0.3",
         "istanbul-lib-coverage": "1.1.1",
-        "istanbul-lib-hook": "1.0.7",
-        "istanbul-lib-instrument": "1.8.0",
-        "istanbul-lib-report": "1.1.1",
-        "istanbul-lib-source-maps": "1.2.1",
-        "istanbul-reports": "1.1.2",
+        "istanbul-lib-hook": "1.1.0",
+        "istanbul-lib-instrument": "1.9.1",
+        "istanbul-lib-report": "1.1.2",
+        "istanbul-lib-source-maps": "1.2.2",
+        "istanbul-reports": "1.1.3",
         "js-yaml": "3.10.0",
         "mkdirp": "0.5.1",
         "once": "1.4.0"
+      },
+      "dependencies": {
+        "istanbul-lib-instrument": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz",
+          "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
+          "dev": true,
+          "requires": {
+            "babel-generator": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "istanbul-lib-coverage": "1.1.1",
+            "semver": "5.4.1"
+          }
+        }
       }
     },
     "istanbul-lib-coverage": {
@@ -1498,9 +1642,9 @@
       "dev": true
     },
     "istanbul-lib-hook": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
-      "integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
+      "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
       "dev": true,
       "requires": {
         "append-transform": "0.4.0"
@@ -1522,9 +1666,9 @@
       }
     },
     "istanbul-lib-report": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
-      "integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
+      "integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
       "dev": true,
       "requires": {
         "istanbul-lib-coverage": "1.1.1",
@@ -1551,12 +1695,12 @@
       }
     },
     "istanbul-lib-source-maps": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
-      "integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
+      "integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
+        "debug": "3.1.0",
         "istanbul-lib-coverage": "1.1.1",
         "mkdirp": "0.5.1",
         "rimraf": "2.6.2",
@@ -1564,33 +1708,71 @@
       }
     },
     "istanbul-reports": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-      "integrity": "sha1-D7Lj9qqZIr085F0F2KtNXo4HvU8=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.3.tgz",
+      "integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
       "dev": true,
       "requires": {
-        "handlebars": "4.0.10"
+        "handlebars": "4.0.11"
       }
     },
     "jest": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-21.2.1.tgz",
-      "integrity": "sha512-mXN0ppPvWYoIcC+R+ctKxAJ28xkt/Z5Js875padm4GbgUn6baeR5N4Ng6LjatIRpUQDZVJABT7Y4gucFjPryfw==",
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-22.0.1.tgz",
+      "integrity": "sha512-88ohFSKDP/2QTvHsRQuGcVHBR3CpwIkInV67NiaKh38ZI4h6h4iZKnyx+cASTO1XFmtI4m5fpzY9MtgNX4gumg==",
       "dev": true,
       "requires": {
-        "jest-cli": "21.2.1"
+        "jest-cli": "22.0.1"
       },
       "dependencies": {
+        "acorn": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+          "dev": true
+        },
+        "acorn-globals": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+          "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.2.1"
+          }
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "expect": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-22.0.1.tgz",
+          "integrity": "sha512-6OjUXqPTCBnOLThrGSSybCedg5VmATP12pbisVld0POf9SqKQyCGAR5wFuP61BoMNGgKZeu6DiQWrd+KNpjbqA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "jest-diff": "22.0.1",
+            "jest-get-type": "22.0.1",
+            "jest-matcher-utils": "22.0.1",
+            "jest-message-util": "22.0.1",
+            "jest-regex-util": "21.2.0"
+          }
+        },
         "jest-cli": {
-          "version": "21.2.1",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-21.2.1.tgz",
-          "integrity": "sha512-T1BzrbFxDIW/LLYQqVfo94y/hhaj1NzVQkZgBumAC+sxbjMROI7VkihOdxNR758iYbQykL2ZOWUBurFgkQrzdg==",
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.0.1.tgz",
+          "integrity": "sha512-2SMwlP9jiEv613IXclDj5psISn1h2b0a30U8SV/eZrGb/z97iTCX+j9xzM41oV8RkX1o/UBuzMpBDDKkz0BK5Q==",
           "dev": true,
           "requires": {
             "ansi-escapes": "3.0.0",
@@ -1598,94 +1780,266 @@
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
             "is-ci": "1.0.10",
-            "istanbul-api": "1.1.14",
+            "istanbul-api": "1.2.1",
             "istanbul-lib-coverage": "1.1.1",
             "istanbul-lib-instrument": "1.8.0",
-            "istanbul-lib-source-maps": "1.2.1",
-            "jest-changed-files": "21.2.0",
-            "jest-config": "21.2.1",
-            "jest-environment-jsdom": "21.2.1",
-            "jest-haste-map": "21.2.0",
-            "jest-message-util": "21.2.1",
+            "istanbul-lib-source-maps": "1.2.2",
+            "jest-changed-files": "22.0.1",
+            "jest-config": "22.0.1",
+            "jest-environment-jsdom": "22.0.1",
+            "jest-get-type": "22.0.1",
+            "jest-haste-map": "22.0.1",
+            "jest-message-util": "22.0.1",
             "jest-regex-util": "21.2.0",
             "jest-resolve-dependencies": "21.2.0",
-            "jest-runner": "21.2.1",
-            "jest-runtime": "21.2.1",
-            "jest-snapshot": "21.2.1",
-            "jest-util": "21.2.1",
+            "jest-runner": "22.0.1",
+            "jest-runtime": "22.0.1",
+            "jest-snapshot": "22.0.1",
+            "jest-util": "22.0.1",
+            "jest-worker": "22.0.1",
             "micromatch": "2.3.11",
             "node-notifier": "5.1.2",
-            "pify": "3.0.0",
+            "realpath-native": "1.0.0",
+            "rimraf": "2.6.2",
             "slash": "1.0.0",
             "string-length": "2.0.0",
             "strip-ansi": "4.0.0",
             "which": "1.3.0",
-            "worker-farm": "1.5.0",
-            "yargs": "9.0.1"
+            "yargs": "10.0.3"
           }
         },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+        "jest-config": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.0.1.tgz",
+          "integrity": "sha512-F+5V7LcrSfivar87ZBikHbeBJor8gtdrQw24uy8ZX7K3js8YLD5ujcQVe8+gL/Jpl77uCRB35P5qD036OClgng==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-              "dev": true
-            }
+            "chalk": "2.1.0",
+            "glob": "7.1.2",
+            "jest-environment-jsdom": "22.0.1",
+            "jest-environment-node": "22.0.1",
+            "jest-get-type": "22.0.1",
+            "jest-jasmine2": "22.0.1",
+            "jest-regex-util": "21.2.0",
+            "jest-resolve": "22.0.1",
+            "jest-util": "22.0.1",
+            "jest-validate": "22.0.1",
+            "pretty-format": "22.0.1"
           }
         },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+        "jest-diff": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.0.1.tgz",
+          "integrity": "sha512-qyaKL+8vi6P2qRwjZv3fEresTlbIxvBz0pRZhw0t/snT9OoxWGHIwzqNaFN7B59e0Krx4u9QgvIsOknHPLfDOA==",
           "dev": true,
           "requires": {
-            "pify": "2.3.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-              "dev": true
-            }
+            "chalk": "2.1.0",
+            "diff": "3.2.0",
+            "jest-get-type": "22.0.1",
+            "pretty-format": "22.0.1"
           }
         },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+        "jest-environment-jsdom": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.0.1.tgz",
+          "integrity": "sha512-BMbad6gGRSSuJ+xgyItNHh8JR8ha0DgZgJd5AP/5Dndo035yxxAA0YFU4CA2qG0vjpvPuscuQef8BG0xeARgFg==",
+          "dev": true,
+          "requires": {
+            "jest-mock": "22.0.1",
+            "jest-util": "22.0.1",
+            "jsdom": "11.5.1"
+          }
+        },
+        "jest-environment-node": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.0.1.tgz",
+          "integrity": "sha512-lieaAFkj0ZXrEgJH84sXADFEVDkIaNw3+1JEGVyFH5h9KkgwU7hP3OUFimYjvj8zaWpRIwMDAnzRai9JPNux7w==",
+          "dev": true,
+          "requires": {
+            "jest-mock": "22.0.1",
+            "jest-util": "22.0.1"
+          }
+        },
+        "jest-get-type": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.0.1.tgz",
+          "integrity": "sha512-Xshee+V9LoVrvVlrS6raLvHYJOcdbmC20syU2/8DzQTU9C7rezJ19KE6EliFWBpSCB3/O5VHUNx3fV0WRszcnA==",
           "dev": true
         },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+        "jest-jasmine2": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.0.1.tgz",
+          "integrity": "sha512-aZUh71ykuInQ9LN1t6/YPti/epNOnVtZGb8IeopnfCZChPwiAiB3GfNhhohc9LEsYxI/StklthOx2Fa1po5i1w==",
           "dev": true,
           "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
+            "callsites": "2.0.0",
+            "chalk": "2.1.0",
+            "expect": "22.0.1",
+            "graceful-fs": "4.1.11",
+            "jest-diff": "22.0.1",
+            "jest-matcher-utils": "22.0.1",
+            "jest-message-util": "22.0.1",
+            "jest-snapshot": "22.0.1",
+            "source-map-support": "0.5.0"
           }
         },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+        "jest-matcher-utils": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.0.1.tgz",
+          "integrity": "sha512-nLd4axY6ZuvXtv2Q+iUUfm2bgP3QYluDnm5ZYrDvu16XIYtxTmlN7EAbA5jkii/lrbsn9F2T+LwxbFqRN26Eew==",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
+            "chalk": "2.1.0",
+            "jest-get-type": "22.0.1",
+            "pretty-format": "22.0.1"
+          }
+        },
+        "jest-message-util": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.0.1.tgz",
+          "integrity": "sha512-bKXLjG9deXubv1GCyb6HCc5zBKgh0mUs+WS3Gm1+t0yk6tf2hpjAS7ukj2lY5/VyjFLwEyR74JwoIg38VrlydA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.35",
+            "chalk": "2.1.0",
+            "micromatch": "2.3.11",
+            "slash": "1.0.0",
+            "stack-utils": "1.0.1"
+          }
+        },
+        "jest-mock": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.0.1.tgz",
+          "integrity": "sha512-ct9U2nYkvGv2kCMGDlz2/D66aAdk0Hd0oGTzNkqeiI4snnQzpJqSu04oQ90Bt1QIOB/R+TvD7qeDCOwEy7OGWQ==",
+          "dev": true
+        },
+        "jest-resolve": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.0.1.tgz",
+          "integrity": "sha512-Ujlt2USNJxj9GK0bHydixACnkqmKl2QJq0nhcEEvTBbcVhpOLs7kM83cNxqmZWP/rRgkTDgH1KIvOSz6r+ApGg==",
+          "dev": true,
+          "requires": {
+            "browser-resolve": "1.11.2",
+            "chalk": "2.1.0"
+          }
+        },
+        "jest-snapshot": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.0.1.tgz",
+          "integrity": "sha512-zYEPUP0YIoTm8w7TmRAgP6sihw+H3gDZ9cZJqH55CpXA0rY1qiAvO257cqHV59pJtv5dekfUnbrezE18ArbFYg==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.1.0",
+            "jest-diff": "22.0.1",
+            "jest-matcher-utils": "22.0.1",
+            "mkdirp": "0.5.1",
+            "natural-compare": "1.4.0",
+            "pretty-format": "22.0.1"
+          }
+        },
+        "jest-util": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.0.1.tgz",
+          "integrity": "sha512-mcLOvom3cEddZwu3/ZjuXbd3YlDIOxn4MzTuIlo2t5L1LFz2ioAC2UNFjuyUAH8YXhZypVYb0uwgMx8WL3PnoQ==",
+          "dev": true,
+          "requires": {
+            "callsites": "2.0.0",
+            "chalk": "2.1.0",
+            "graceful-fs": "4.1.11",
+            "is-ci": "1.0.10",
+            "jest-message-util": "22.0.1",
+            "jest-validate": "22.0.1",
+            "mkdirp": "0.5.1"
+          }
+        },
+        "jest-validate": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.0.1.tgz",
+          "integrity": "sha512-VVzQAyDfLe5mI6rBa0ryHyado5aJ2eH+mZwkXHd+D65wGdRgKmzv/CGhbHfkReHbrvnKz9ptuucTNj1WDWb86A==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.1.0",
+            "jest-get-type": "22.0.1",
+            "leven": "2.1.0",
+            "pretty-format": "22.0.1"
+          }
+        },
+        "jsdom": {
+          "version": "11.5.1",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.5.1.tgz",
+          "integrity": "sha512-89ztIZ03aYK9f1uUrLXLsZndRge/JnZjzjpaN+lrse3coqz+8PR/dX4WLHpbF5fIKTXhDjFODOJw2328lPJ90g==",
+          "dev": true,
+          "requires": {
+            "abab": "1.0.4",
+            "acorn": "5.2.1",
+            "acorn-globals": "4.1.0",
+            "array-equal": "1.0.0",
+            "browser-process-hrtime": "0.1.2",
+            "content-type-parser": "1.0.1",
+            "cssom": "0.3.2",
+            "cssstyle": "0.2.37",
+            "domexception": "1.0.0",
+            "escodegen": "1.9.0",
+            "html-encoding-sniffer": "1.0.1",
+            "left-pad": "1.2.0",
+            "nwmatcher": "1.4.3",
+            "parse5": "3.0.3",
+            "pn": "1.0.0",
+            "request": "2.83.0",
+            "request-promise-native": "1.0.5",
+            "sax": "1.2.4",
+            "symbol-tree": "3.2.2",
+            "tough-cookie": "2.3.3",
+            "webidl-conversions": "4.0.2",
+            "whatwg-encoding": "1.0.1",
+            "whatwg-url": "6.4.0",
+            "xml-name-validator": "2.0.1"
+          }
+        },
+        "nwmatcher": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
+          "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
+          "dev": true
+        },
+        "parse5": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "8.0.31"
+          }
+        },
+        "pretty-format": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.0.1.tgz",
+          "integrity": "sha512-/66A0zEbZUzAH4Xtk3szLp9LERQtq25lwrBygaMK4yg+KWKwZOmpAQUMmYr2uA9bqGogoz0Vu9SrUbeV7Tbwxg==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0",
+            "ansi-styles": "3.2.0"
+          }
+        },
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
+          "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.6.1"
           }
         },
         "strip-ansi": {
@@ -1697,39 +2051,61 @@
             "ansi-regex": "3.0.0"
           }
         },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
-          "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
+            "punycode": "2.1.0"
+          }
+        },
+        "whatwg-url": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+          "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "4.7.0",
+            "tr46": "1.0.1",
+            "webidl-conversions": "4.0.2"
+          }
+        },
+        "yargs": {
+          "version": "10.0.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+          "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+          "dev": true,
+          "requires": {
             "cliui": "3.2.0",
             "decamelize": "1.2.0",
+            "find-up": "2.1.0",
             "get-caller-file": "1.0.2",
             "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
             "require-directory": "2.1.1",
             "require-main-filename": "1.0.1",
             "set-blocking": "2.0.0",
             "string-width": "2.1.1",
             "which-module": "2.0.0",
             "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
+            "yargs-parser": "8.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+          "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0"
           }
         }
       }
     },
     "jest-changed-files": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-21.2.0.tgz",
-      "integrity": "sha512-+lCNP1IZLwN1NOIvBcV5zEL6GENK6TXrDj4UxWIeLvIsIDa+gf6J7hkqsW2qVVt/wvH65rVvcPwqXdps5eclTQ==",
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.0.1.tgz",
+      "integrity": "sha512-I1WfAAi+wBgjlMxqRTLT1kOHgyR3egQi4BmG787KleqpoRGyUHkNfDBmzXwxypfxlqing0nqFUCWP5gP+jjVdg==",
       "dev": true,
       "requires": {
         "throat": "4.1.0"
@@ -1767,10 +2143,13 @@
       }
     },
     "jest-docblock": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
-      "dev": true
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.0.1.tgz",
+      "integrity": "sha512-7MPdavUJjHJTJjRjSf4wfV82t6Ig2bcK/VqU0kRHZPpdPkATU5tYj4yKp/RbC2pgu28xQpYax7AxztoKv3BL4g==",
+      "dev": true,
+      "requires": {
+        "detect-newline": "2.1.0"
+      }
     },
     "jest-environment-jsdom": {
       "version": "21.2.1",
@@ -1800,17 +2179,17 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-21.2.0.tgz",
-      "integrity": "sha512-5LhsY/loPH7wwOFRMs+PT4aIAORJ2qwgbpMFlbWbxfN0bk3ZCwxJ530vrbSiTstMkYLao6JwBkLhCJ5XbY7ZHw==",
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.0.1.tgz",
+      "integrity": "sha512-k5NacCBk8zz1XfMBK75XxzljjeUz93LdS0RZorkFhZ2vc1BJgSIOqv/soFtCHt9jdCUDzi/XmnJ297xUAc5iEA==",
       "dev": true,
       "requires": {
         "fb-watchman": "2.0.0",
         "graceful-fs": "4.1.11",
-        "jest-docblock": "21.2.0",
+        "jest-docblock": "22.0.1",
+        "jest-worker": "22.0.1",
         "micromatch": "2.3.11",
-        "sane": "2.2.0",
-        "worker-farm": "1.5.0"
+        "sane": "2.2.0"
       }
     },
     "jest-jasmine2": {
@@ -1827,6 +2206,43 @@
         "jest-message-util": "21.2.1",
         "jest-snapshot": "21.2.1",
         "p-cancelable": "0.3.0"
+      }
+    },
+    "jest-leak-detector": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.0.1.tgz",
+      "integrity": "sha512-X175D/mqqdYBatSU/u+ctOEtlUp2UETmLHEvxJvP0pjRZ+9mZ/CBFJ+GB6cOTS1a1gN6gT9YMpw3m9suKiuvdw==",
+      "dev": true,
+      "requires": {
+        "pretty-format": "22.0.1",
+        "weak": "1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "pretty-format": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.0.1.tgz",
+          "integrity": "sha512-/66A0zEbZUzAH4Xtk3szLp9LERQtq25lwrBygaMK4yg+KWKwZOmpAQUMmYr2uA9bqGogoz0Vu9SrUbeV7Tbwxg==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0",
+            "ansi-styles": "3.2.0"
+          }
+        }
       }
     },
     "jest-matcher-utils": {
@@ -1884,96 +2300,625 @@
       }
     },
     "jest-runner": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-21.2.1.tgz",
-      "integrity": "sha512-Anb72BOQlHqF/zETqZ2K20dbYsnqW/nZO7jV8BYENl+3c44JhMrA8zd1lt52+N7ErnsQMd2HHKiVwN9GYSXmrg==",
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.0.1.tgz",
+      "integrity": "sha512-5V/6DsKd250DuaHDCBAQ8uGzFR3tDHQOdGG+qGrmDR8gQMhYjarXDUfAafUFgMliDBtExNi+VBUeKpDn/lr+Wg==",
       "dev": true,
       "requires": {
-        "jest-config": "21.2.1",
-        "jest-docblock": "21.2.0",
-        "jest-haste-map": "21.2.0",
-        "jest-jasmine2": "21.2.1",
-        "jest-message-util": "21.2.1",
-        "jest-runtime": "21.2.1",
-        "jest-util": "21.2.1",
-        "pify": "3.0.0",
-        "throat": "4.1.0",
-        "worker-farm": "1.5.0"
+        "jest-config": "22.0.1",
+        "jest-docblock": "22.0.1",
+        "jest-haste-map": "22.0.1",
+        "jest-jasmine2": "22.0.1",
+        "jest-leak-detector": "22.0.1",
+        "jest-message-util": "22.0.1",
+        "jest-runtime": "22.0.1",
+        "jest-util": "22.0.1",
+        "jest-worker": "22.0.1",
+        "throat": "4.1.0"
       },
       "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+        "acorn": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
           "dev": true
+        },
+        "acorn-globals": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+          "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.2.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "expect": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-22.0.1.tgz",
+          "integrity": "sha512-6OjUXqPTCBnOLThrGSSybCedg5VmATP12pbisVld0POf9SqKQyCGAR5wFuP61BoMNGgKZeu6DiQWrd+KNpjbqA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "jest-diff": "22.0.1",
+            "jest-get-type": "22.0.1",
+            "jest-matcher-utils": "22.0.1",
+            "jest-message-util": "22.0.1",
+            "jest-regex-util": "21.2.0"
+          }
+        },
+        "jest-config": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.0.1.tgz",
+          "integrity": "sha512-F+5V7LcrSfivar87ZBikHbeBJor8gtdrQw24uy8ZX7K3js8YLD5ujcQVe8+gL/Jpl77uCRB35P5qD036OClgng==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.1.0",
+            "glob": "7.1.2",
+            "jest-environment-jsdom": "22.0.1",
+            "jest-environment-node": "22.0.1",
+            "jest-get-type": "22.0.1",
+            "jest-jasmine2": "22.0.1",
+            "jest-regex-util": "21.2.0",
+            "jest-resolve": "22.0.1",
+            "jest-util": "22.0.1",
+            "jest-validate": "22.0.1",
+            "pretty-format": "22.0.1"
+          }
+        },
+        "jest-diff": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.0.1.tgz",
+          "integrity": "sha512-qyaKL+8vi6P2qRwjZv3fEresTlbIxvBz0pRZhw0t/snT9OoxWGHIwzqNaFN7B59e0Krx4u9QgvIsOknHPLfDOA==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.1.0",
+            "diff": "3.2.0",
+            "jest-get-type": "22.0.1",
+            "pretty-format": "22.0.1"
+          }
+        },
+        "jest-environment-jsdom": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.0.1.tgz",
+          "integrity": "sha512-BMbad6gGRSSuJ+xgyItNHh8JR8ha0DgZgJd5AP/5Dndo035yxxAA0YFU4CA2qG0vjpvPuscuQef8BG0xeARgFg==",
+          "dev": true,
+          "requires": {
+            "jest-mock": "22.0.1",
+            "jest-util": "22.0.1",
+            "jsdom": "11.5.1"
+          }
+        },
+        "jest-environment-node": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.0.1.tgz",
+          "integrity": "sha512-lieaAFkj0ZXrEgJH84sXADFEVDkIaNw3+1JEGVyFH5h9KkgwU7hP3OUFimYjvj8zaWpRIwMDAnzRai9JPNux7w==",
+          "dev": true,
+          "requires": {
+            "jest-mock": "22.0.1",
+            "jest-util": "22.0.1"
+          }
+        },
+        "jest-get-type": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.0.1.tgz",
+          "integrity": "sha512-Xshee+V9LoVrvVlrS6raLvHYJOcdbmC20syU2/8DzQTU9C7rezJ19KE6EliFWBpSCB3/O5VHUNx3fV0WRszcnA==",
+          "dev": true
+        },
+        "jest-jasmine2": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.0.1.tgz",
+          "integrity": "sha512-aZUh71ykuInQ9LN1t6/YPti/epNOnVtZGb8IeopnfCZChPwiAiB3GfNhhohc9LEsYxI/StklthOx2Fa1po5i1w==",
+          "dev": true,
+          "requires": {
+            "callsites": "2.0.0",
+            "chalk": "2.1.0",
+            "expect": "22.0.1",
+            "graceful-fs": "4.1.11",
+            "jest-diff": "22.0.1",
+            "jest-matcher-utils": "22.0.1",
+            "jest-message-util": "22.0.1",
+            "jest-snapshot": "22.0.1",
+            "source-map-support": "0.5.0"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.0.1.tgz",
+          "integrity": "sha512-nLd4axY6ZuvXtv2Q+iUUfm2bgP3QYluDnm5ZYrDvu16XIYtxTmlN7EAbA5jkii/lrbsn9F2T+LwxbFqRN26Eew==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.1.0",
+            "jest-get-type": "22.0.1",
+            "pretty-format": "22.0.1"
+          }
+        },
+        "jest-message-util": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.0.1.tgz",
+          "integrity": "sha512-bKXLjG9deXubv1GCyb6HCc5zBKgh0mUs+WS3Gm1+t0yk6tf2hpjAS7ukj2lY5/VyjFLwEyR74JwoIg38VrlydA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.35",
+            "chalk": "2.1.0",
+            "micromatch": "2.3.11",
+            "slash": "1.0.0",
+            "stack-utils": "1.0.1"
+          }
+        },
+        "jest-mock": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.0.1.tgz",
+          "integrity": "sha512-ct9U2nYkvGv2kCMGDlz2/D66aAdk0Hd0oGTzNkqeiI4snnQzpJqSu04oQ90Bt1QIOB/R+TvD7qeDCOwEy7OGWQ==",
+          "dev": true
+        },
+        "jest-resolve": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.0.1.tgz",
+          "integrity": "sha512-Ujlt2USNJxj9GK0bHydixACnkqmKl2QJq0nhcEEvTBbcVhpOLs7kM83cNxqmZWP/rRgkTDgH1KIvOSz6r+ApGg==",
+          "dev": true,
+          "requires": {
+            "browser-resolve": "1.11.2",
+            "chalk": "2.1.0"
+          }
+        },
+        "jest-snapshot": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.0.1.tgz",
+          "integrity": "sha512-zYEPUP0YIoTm8w7TmRAgP6sihw+H3gDZ9cZJqH55CpXA0rY1qiAvO257cqHV59pJtv5dekfUnbrezE18ArbFYg==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.1.0",
+            "jest-diff": "22.0.1",
+            "jest-matcher-utils": "22.0.1",
+            "mkdirp": "0.5.1",
+            "natural-compare": "1.4.0",
+            "pretty-format": "22.0.1"
+          }
+        },
+        "jest-util": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.0.1.tgz",
+          "integrity": "sha512-mcLOvom3cEddZwu3/ZjuXbd3YlDIOxn4MzTuIlo2t5L1LFz2ioAC2UNFjuyUAH8YXhZypVYb0uwgMx8WL3PnoQ==",
+          "dev": true,
+          "requires": {
+            "callsites": "2.0.0",
+            "chalk": "2.1.0",
+            "graceful-fs": "4.1.11",
+            "is-ci": "1.0.10",
+            "jest-message-util": "22.0.1",
+            "jest-validate": "22.0.1",
+            "mkdirp": "0.5.1"
+          }
+        },
+        "jest-validate": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.0.1.tgz",
+          "integrity": "sha512-VVzQAyDfLe5mI6rBa0ryHyado5aJ2eH+mZwkXHd+D65wGdRgKmzv/CGhbHfkReHbrvnKz9ptuucTNj1WDWb86A==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.1.0",
+            "jest-get-type": "22.0.1",
+            "leven": "2.1.0",
+            "pretty-format": "22.0.1"
+          }
+        },
+        "jsdom": {
+          "version": "11.5.1",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.5.1.tgz",
+          "integrity": "sha512-89ztIZ03aYK9f1uUrLXLsZndRge/JnZjzjpaN+lrse3coqz+8PR/dX4WLHpbF5fIKTXhDjFODOJw2328lPJ90g==",
+          "dev": true,
+          "requires": {
+            "abab": "1.0.4",
+            "acorn": "5.2.1",
+            "acorn-globals": "4.1.0",
+            "array-equal": "1.0.0",
+            "browser-process-hrtime": "0.1.2",
+            "content-type-parser": "1.0.1",
+            "cssom": "0.3.2",
+            "cssstyle": "0.2.37",
+            "domexception": "1.0.0",
+            "escodegen": "1.9.0",
+            "html-encoding-sniffer": "1.0.1",
+            "left-pad": "1.2.0",
+            "nwmatcher": "1.4.3",
+            "parse5": "3.0.3",
+            "pn": "1.0.0",
+            "request": "2.83.0",
+            "request-promise-native": "1.0.5",
+            "sax": "1.2.4",
+            "symbol-tree": "3.2.2",
+            "tough-cookie": "2.3.3",
+            "webidl-conversions": "4.0.2",
+            "whatwg-encoding": "1.0.1",
+            "whatwg-url": "6.4.0",
+            "xml-name-validator": "2.0.1"
+          }
+        },
+        "nwmatcher": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
+          "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
+          "dev": true
+        },
+        "parse5": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "8.0.31"
+          }
+        },
+        "pretty-format": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.0.1.tgz",
+          "integrity": "sha512-/66A0zEbZUzAH4Xtk3szLp9LERQtq25lwrBygaMK4yg+KWKwZOmpAQUMmYr2uA9bqGogoz0Vu9SrUbeV7Tbwxg==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0",
+            "ansi-styles": "3.2.0"
+          }
+        },
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
+          "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.6.1"
+          }
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
+          "requires": {
+            "punycode": "2.1.0"
+          }
+        },
+        "whatwg-url": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+          "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "4.7.0",
+            "tr46": "1.0.1",
+            "webidl-conversions": "4.0.2"
+          }
         }
       }
     },
     "jest-runtime": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-21.2.1.tgz",
-      "integrity": "sha512-6omlpA3+NSE+rHwD0PQjNEjZeb2z+oRmuehMfM1tWQVum+E0WV3pFt26Am0DUfQkkPyTABvxITRjCUclYgSOsA==",
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.0.1.tgz",
+      "integrity": "sha512-WF8eKSTxWPIiUHkfWPKGaLjRwA/IxWmBgO41xYc0gqZEDdEibplcbg3C/+o1pqi/1Nzix3N6GaVMpOiSBFFMpw==",
       "dev": true,
       "requires": {
         "babel-core": "6.26.0",
-        "babel-jest": "21.2.0",
+        "babel-jest": "22.0.1",
         "babel-plugin-istanbul": "4.1.5",
         "chalk": "2.1.0",
         "convert-source-map": "1.5.0",
         "graceful-fs": "4.1.11",
-        "jest-config": "21.2.1",
-        "jest-haste-map": "21.2.0",
+        "jest-config": "22.0.1",
+        "jest-haste-map": "22.0.1",
         "jest-regex-util": "21.2.0",
-        "jest-resolve": "21.2.0",
-        "jest-util": "21.2.1",
+        "jest-resolve": "22.0.1",
+        "jest-util": "22.0.1",
         "json-stable-stringify": "1.0.1",
         "micromatch": "2.3.11",
+        "realpath-native": "1.0.0",
         "slash": "1.0.0",
         "strip-bom": "3.0.0",
         "write-file-atomic": "2.3.0",
-        "yargs": "9.0.1"
+        "yargs": "10.0.3"
       },
       "dependencies": {
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+        "acorn": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+          "dev": true
+        },
+        "acorn-globals": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+          "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
           "dev": true,
           "requires": {
+            "acorn": "5.2.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "expect": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-22.0.1.tgz",
+          "integrity": "sha512-6OjUXqPTCBnOLThrGSSybCedg5VmATP12pbisVld0POf9SqKQyCGAR5wFuP61BoMNGgKZeu6DiQWrd+KNpjbqA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "jest-diff": "22.0.1",
+            "jest-get-type": "22.0.1",
+            "jest-matcher-utils": "22.0.1",
+            "jest-message-util": "22.0.1",
+            "jest-regex-util": "21.2.0"
+          }
+        },
+        "jest-config": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.0.1.tgz",
+          "integrity": "sha512-F+5V7LcrSfivar87ZBikHbeBJor8gtdrQw24uy8ZX7K3js8YLD5ujcQVe8+gL/Jpl77uCRB35P5qD036OClgng==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.1.0",
+            "glob": "7.1.2",
+            "jest-environment-jsdom": "22.0.1",
+            "jest-environment-node": "22.0.1",
+            "jest-get-type": "22.0.1",
+            "jest-jasmine2": "22.0.1",
+            "jest-regex-util": "21.2.0",
+            "jest-resolve": "22.0.1",
+            "jest-util": "22.0.1",
+            "jest-validate": "22.0.1",
+            "pretty-format": "22.0.1"
+          }
+        },
+        "jest-diff": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.0.1.tgz",
+          "integrity": "sha512-qyaKL+8vi6P2qRwjZv3fEresTlbIxvBz0pRZhw0t/snT9OoxWGHIwzqNaFN7B59e0Krx4u9QgvIsOknHPLfDOA==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.1.0",
+            "diff": "3.2.0",
+            "jest-get-type": "22.0.1",
+            "pretty-format": "22.0.1"
+          }
+        },
+        "jest-environment-jsdom": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.0.1.tgz",
+          "integrity": "sha512-BMbad6gGRSSuJ+xgyItNHh8JR8ha0DgZgJd5AP/5Dndo035yxxAA0YFU4CA2qG0vjpvPuscuQef8BG0xeARgFg==",
+          "dev": true,
+          "requires": {
+            "jest-mock": "22.0.1",
+            "jest-util": "22.0.1",
+            "jsdom": "11.5.1"
+          }
+        },
+        "jest-environment-node": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.0.1.tgz",
+          "integrity": "sha512-lieaAFkj0ZXrEgJH84sXADFEVDkIaNw3+1JEGVyFH5h9KkgwU7hP3OUFimYjvj8zaWpRIwMDAnzRai9JPNux7w==",
+          "dev": true,
+          "requires": {
+            "jest-mock": "22.0.1",
+            "jest-util": "22.0.1"
+          }
+        },
+        "jest-get-type": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.0.1.tgz",
+          "integrity": "sha512-Xshee+V9LoVrvVlrS6raLvHYJOcdbmC20syU2/8DzQTU9C7rezJ19KE6EliFWBpSCB3/O5VHUNx3fV0WRszcnA==",
+          "dev": true
+        },
+        "jest-jasmine2": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.0.1.tgz",
+          "integrity": "sha512-aZUh71ykuInQ9LN1t6/YPti/epNOnVtZGb8IeopnfCZChPwiAiB3GfNhhohc9LEsYxI/StklthOx2Fa1po5i1w==",
+          "dev": true,
+          "requires": {
+            "callsites": "2.0.0",
+            "chalk": "2.1.0",
+            "expect": "22.0.1",
             "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
+            "jest-diff": "22.0.1",
+            "jest-matcher-utils": "22.0.1",
+            "jest-message-util": "22.0.1",
+            "jest-snapshot": "22.0.1",
+            "source-map-support": "0.5.0"
           }
         },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+        "jest-matcher-utils": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.0.1.tgz",
+          "integrity": "sha512-nLd4axY6ZuvXtv2Q+iUUfm2bgP3QYluDnm5ZYrDvu16XIYtxTmlN7EAbA5jkii/lrbsn9F2T+LwxbFqRN26Eew==",
           "dev": true,
           "requires": {
-            "pify": "2.3.0"
+            "chalk": "2.1.0",
+            "jest-get-type": "22.0.1",
+            "pretty-format": "22.0.1"
           }
         },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+        "jest-message-util": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.0.1.tgz",
+          "integrity": "sha512-bKXLjG9deXubv1GCyb6HCc5zBKgh0mUs+WS3Gm1+t0yk6tf2hpjAS7ukj2lY5/VyjFLwEyR74JwoIg38VrlydA==",
           "dev": true,
           "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
+            "@babel/code-frame": "7.0.0-beta.35",
+            "chalk": "2.1.0",
+            "micromatch": "2.3.11",
+            "slash": "1.0.0",
+            "stack-utils": "1.0.1"
           }
         },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+        "jest-mock": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.0.1.tgz",
+          "integrity": "sha512-ct9U2nYkvGv2kCMGDlz2/D66aAdk0Hd0oGTzNkqeiI4snnQzpJqSu04oQ90Bt1QIOB/R+TvD7qeDCOwEy7OGWQ==",
+          "dev": true
+        },
+        "jest-resolve": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.0.1.tgz",
+          "integrity": "sha512-Ujlt2USNJxj9GK0bHydixACnkqmKl2QJq0nhcEEvTBbcVhpOLs7kM83cNxqmZWP/rRgkTDgH1KIvOSz6r+ApGg==",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
+            "browser-resolve": "1.11.2",
+            "chalk": "2.1.0"
+          }
+        },
+        "jest-snapshot": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.0.1.tgz",
+          "integrity": "sha512-zYEPUP0YIoTm8w7TmRAgP6sihw+H3gDZ9cZJqH55CpXA0rY1qiAvO257cqHV59pJtv5dekfUnbrezE18ArbFYg==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.1.0",
+            "jest-diff": "22.0.1",
+            "jest-matcher-utils": "22.0.1",
+            "mkdirp": "0.5.1",
+            "natural-compare": "1.4.0",
+            "pretty-format": "22.0.1"
+          }
+        },
+        "jest-util": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.0.1.tgz",
+          "integrity": "sha512-mcLOvom3cEddZwu3/ZjuXbd3YlDIOxn4MzTuIlo2t5L1LFz2ioAC2UNFjuyUAH8YXhZypVYb0uwgMx8WL3PnoQ==",
+          "dev": true,
+          "requires": {
+            "callsites": "2.0.0",
+            "chalk": "2.1.0",
+            "graceful-fs": "4.1.11",
+            "is-ci": "1.0.10",
+            "jest-message-util": "22.0.1",
+            "jest-validate": "22.0.1",
+            "mkdirp": "0.5.1"
+          }
+        },
+        "jest-validate": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.0.1.tgz",
+          "integrity": "sha512-VVzQAyDfLe5mI6rBa0ryHyado5aJ2eH+mZwkXHd+D65wGdRgKmzv/CGhbHfkReHbrvnKz9ptuucTNj1WDWb86A==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.1.0",
+            "jest-get-type": "22.0.1",
+            "leven": "2.1.0",
+            "pretty-format": "22.0.1"
+          }
+        },
+        "jsdom": {
+          "version": "11.5.1",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.5.1.tgz",
+          "integrity": "sha512-89ztIZ03aYK9f1uUrLXLsZndRge/JnZjzjpaN+lrse3coqz+8PR/dX4WLHpbF5fIKTXhDjFODOJw2328lPJ90g==",
+          "dev": true,
+          "requires": {
+            "abab": "1.0.4",
+            "acorn": "5.2.1",
+            "acorn-globals": "4.1.0",
+            "array-equal": "1.0.0",
+            "browser-process-hrtime": "0.1.2",
+            "content-type-parser": "1.0.1",
+            "cssom": "0.3.2",
+            "cssstyle": "0.2.37",
+            "domexception": "1.0.0",
+            "escodegen": "1.9.0",
+            "html-encoding-sniffer": "1.0.1",
+            "left-pad": "1.2.0",
+            "nwmatcher": "1.4.3",
+            "parse5": "3.0.3",
+            "pn": "1.0.0",
+            "request": "2.83.0",
+            "request-promise-native": "1.0.5",
+            "sax": "1.2.4",
+            "symbol-tree": "3.2.2",
+            "tough-cookie": "2.3.3",
+            "webidl-conversions": "4.0.2",
+            "whatwg-encoding": "1.0.1",
+            "whatwg-url": "6.4.0",
+            "xml-name-validator": "2.0.1"
+          }
+        },
+        "nwmatcher": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
+          "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
+          "dev": true
+        },
+        "parse5": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "8.0.31"
+          }
+        },
+        "pretty-format": {
+          "version": "22.0.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.0.1.tgz",
+          "integrity": "sha512-/66A0zEbZUzAH4Xtk3szLp9LERQtq25lwrBygaMK4yg+KWKwZOmpAQUMmYr2uA9bqGogoz0Vu9SrUbeV7Tbwxg==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0",
+            "ansi-styles": "3.2.0"
+          }
+        },
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
+          "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.6.1"
           }
         },
         "strip-bom": {
@@ -1982,25 +2927,53 @@
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
-        "yargs": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
-          "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
+            "punycode": "2.1.0"
+          }
+        },
+        "whatwg-url": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+          "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "4.7.0",
+            "tr46": "1.0.1",
+            "webidl-conversions": "4.0.2"
+          }
+        },
+        "yargs": {
+          "version": "10.0.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+          "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+          "dev": true,
+          "requires": {
             "cliui": "3.2.0",
             "decamelize": "1.2.0",
+            "find-up": "2.1.0",
             "get-caller-file": "1.0.2",
             "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
             "require-directory": "2.1.1",
             "require-main-filename": "1.0.1",
             "set-blocking": "2.0.0",
             "string-width": "2.1.1",
             "which-module": "2.0.0",
             "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
+            "yargs-parser": "8.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+          "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -2044,6 +3017,15 @@
         "jest-get-type": "21.2.0",
         "leven": "2.1.0",
         "pretty-format": "21.2.1"
+      }
+    },
+    "jest-worker": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.0.1.tgz",
+      "integrity": "sha512-7QO8mD0XOhwrJDUlpMdqb2cqTabrL0qwWz0yDuP3GTzw7SNPt9TXnkHvT0sPzabtFgtAWafVhu6e8C4HyvKsTA==",
+      "dev": true,
+      "requires": {
+        "merge-stream": "1.0.1"
       }
     },
     "js-tokens": {
@@ -2195,6 +3177,12 @@
         "invert-kv": "1.0.0"
       }
     },
+    "left-pad": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
+      "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
+      "dev": true
+    },
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -2238,6 +3226,12 @@
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "longest": {
@@ -2288,6 +3282,15 @@
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
       "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
       "dev": true
+    },
+    "merge-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
     },
     "micromatch": {
       "version": "2.3.11",
@@ -2360,6 +3363,13 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "dev": true,
+      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -2438,6 +3448,22 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0"
+      }
     },
     "object.omit": {
       "version": "2.0.1",
@@ -2638,6 +3664,12 @@
         "find-up": "2.1.0"
       }
     },
+    "pn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.0.0.tgz",
+      "integrity": "sha1-HPWjCw2AbNGPiPxBprXUrWFbO6k=",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -2683,10 +3715,10 @@
       "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
       "dev": true
     },
-    "prr": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
     },
     "pseudomap": {
@@ -2790,6 +3822,30 @@
         }
       }
     },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "realpath-native": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
+      "integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
+      "dev": true,
+      "requires": {
+        "util.promisify": "1.0.0"
+      }
+    },
     "regenerator-runtime": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
@@ -2860,6 +3916,26 @@
         "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
         "uuid": "3.1.0"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "dev": true,
+      "requires": {
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.3"
       }
     },
     "require-directory": {
@@ -3049,6 +4125,18 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "stack-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
+      "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+      "dev": true
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -3107,6 +4195,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -3431,6 +4528,22 @@
       "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
       "dev": true
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "util.promisify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "object.getownpropertydescriptors": "2.0.3"
+      }
+    },
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
@@ -3519,6 +4632,17 @@
         }
       }
     },
+    "weak": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/weak/-/weak-1.0.1.tgz",
+      "integrity": "sha1-q5mqswcGlZqgIAy4z1RbucszuZ4=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bindings": "1.3.0",
+        "nan": "2.8.0"
+      }
+    },
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -3580,16 +4704,6 @@
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
-    "worker-farm": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.0.tgz",
-      "integrity": "sha512-DHRiUggxtbruaTwnLDm2/BRDKZIoOYvrgYUj5Bam4fU6Gtvc0FaEyoswFPBjMXAweGW2H4BDNIpy//1yXXuaqQ==",
-      "dev": true,
-      "requires": {
-        "errno": "0.1.4",
-        "xtend": "4.0.1"
-      }
-    },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
@@ -3634,12 +4748,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
       "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
-      "dev": true
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@types/jest": "^21.1.2",
     "@types/node": "^8.0.31",
-    "jest": "^21.2.1",
+    "jest": "^22.0.1",
     "ts-jest": "^21.0.1",
     "tslint": "^5.7.0",
     "tslint-config-airbnb": "^5.3.0",


### PR DESCRIPTION
This PR merges in Greenkeeper's updates for version 22.0.1 of jest. The previous PR (#22) will be rejected as 22.0.0 has a breaking bug related to test coverage of TS files.