### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,15 +14,11 @@
   "labels": [
     "dependencies"
   ],
+  "semanticCommits": false,
   "bazel": {
-    "enabled": true,
     "commitMessage": "chore(package): verify integration test status for Atom {{newVersion}}",
     "prTitle": "fix(package): fix integration test failure for {{depName}} version {{#if isRange}}{{newVersion}}{{else}}{{#if isMajor}}{{newVersionMajor}}.x{{else}}{{newVersion}}{{/if}}{{/if}}",
     "packageRules": [
-      {
-        "packageNames": [ "atom-stable" ],
-        "ignoreUnstable": true
-      },
       {
         "packageNames": [ "atom-beta" ],
         "ignoreUnstable": false


### PR DESCRIPTION
- Set semanticCommits to false so that manual prefixes are used instead
- Remove unnecessary rules that are default anyway