### PR TITLE
fix(package): update Renovate config & trigger new patch version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,5 +30,10 @@
         "ignoreUnstable": false
       }
     ]
+  },
+  "packageRules": {
+    "packageNames": [ "typescript" ],
+    "updateTypes": [ "major" ],
+    "commitMessage": "fix(package): update peerDependency to accept typescript ^{{newVersion}}"
   }
 }


### PR DESCRIPTION
This fix should allow Renovate and semantic-release to automatically push a new patch version to npm when integration tests pass against a new major version of TypeScript

**Related issues (if any):** #68 
**Type of request:** 🐛Bugfix
**Proposed milestone:** 🥉Patch